### PR TITLE
Fixing createGraphIndex method to pass through the optional backend parameter

### DIFF
--- a/src/JanusGraphManager.ts
+++ b/src/JanusGraphManager.ts
@@ -93,7 +93,7 @@ export class JanusGraphManager {
     async createGraphIndex(index: GraphIndex, commit = false): Promise<number> {
         await this.init();
         const builder = new GraphIndexBuilder(index.name);
-        builder.label(index.label).type(index.type).unique(index.unique);
+        builder.label(index.label).type(index.type).unique(index.unique).backend(index.backend);
         index.keys.forEach((k) => builder.key(k));
         try {
             await this.client.submit(builder.build());


### PR DESCRIPTION
createGraphIndex was ignoring the `backend` parameter instead of passing it through. Thus, `backend` was always using the default value of `search`.