### PR TITLE
Fix VertexCentric Indices

### DIFF
--- a/src/JanusGraphManager.ts
+++ b/src/JanusGraphManager.ts
@@ -226,7 +226,7 @@ export class JanusGraphManager {
             });
             const vci = schema.vcIndices.map((i) => {
                 const builder = new EnableIndexBuilder(i.name, schema.name);
-                return builder.type('VertexCentric').label(i.edgelabel).build();
+                return builder.type('VertexCentric').label(i.edgelabel).action('REINDEX').build();
             });
             const count = (
                 await Promise.all(

--- a/src/builders/EnableIndexBuilder.spec.ts
+++ b/src/builders/EnableIndexBuilder.spec.ts
@@ -21,7 +21,7 @@ describe('EnableIndexBuilder', () => {
         const eib = new EnableIndexBuilder('test');
         const out = eib.type('VertexCentric').label('testlabel').build();
         expect(out).toEqual(
-            `mgmt.updateIndex(mgmt.getRelationIndex(graph, 'test', 'testlabel'), SchemaAction.ENABLE_INDEX).get();`
+            `mgmt.updateIndex(mgmt.getRelationIndex(mgmt.getEdgeLabel('testlabel'), 'test'), SchemaAction.ENABLE_INDEX).get();`
         );
     });
 
@@ -29,7 +29,7 @@ describe('EnableIndexBuilder', () => {
         const eib = new EnableIndexBuilder('test', 'testgraph');
         const out = eib.type('VertexCentric').label('testlabel').build();
         expect(out).toEqual(
-            `mgmt.updateIndex(mgmt.getRelationIndex(testgraph, 'test', 'testlabel'), SchemaAction.ENABLE_INDEX).get();`
+            `mgmt.updateIndex(mgmt.getRelationIndex(mgmt.getEdgeLabel('testlabel'), 'test'), SchemaAction.ENABLE_INDEX).get();`
         );
     });
 

--- a/src/builders/EnableIndexBuilder.ts
+++ b/src/builders/EnableIndexBuilder.ts
@@ -55,7 +55,7 @@ export class EnableIndexBuilder implements Builder<string> {
                 throw Error(
                     `Vertex Centric index '${this._name}' attempted to be enabled without a label definition.`
                 );
-            output += `mgmt.getRelationIndex(${this._graph}, '${this._name}', '${this._label}')`;
+            output += `mgmt.getRelationIndex(mgmt.getEdgeLabel('${this._label}'), '${this._name}')`;
         } else {
             output += `mgmt.getGraphIndex('${this._name}')`;
         }

--- a/src/builders/VertexCentricIndexBuilder.spec.ts
+++ b/src/builders/VertexCentricIndexBuilder.spec.ts
@@ -9,7 +9,7 @@ describe('VertexCentricIndexBuilder', () => {
             .direction('BOTH')
             .build();
         // Conditional build
-        expect(out).toContain(`if (!mgmt.containsGraphIndex('test'))`);
+        expect(out).toContain(`if (!mgmt.containsRelationIndex(mgmt.getEdgeLabel('testlabel'), 'test'))`);
         expect(out).toContain(
             `mgmt.buildEdgeIndex(mgmt.getEdgeLabel('testlabel'), 'test', Direction.BOTH, Order.asc, mgmt.getPropertyKey('testkey'));`
         );
@@ -49,7 +49,7 @@ describe('VertexCentricIndexBuilder', () => {
             .direction('BOTH')
             .build();
         expect(out).toContain(
-            `mgmt.buildEdgeIndex(mgmt.getEdgeLabel('testlabel'), 'test', Direction.BOTH, Order.asc, mgmt.getPropertyKey('testkey'));`
+            `mgmt.buildEdgeIndex(mgmt.getEdgeLabel('testlabel'), 'test', Direction.BOTH, Order.asc, mgmt.getPropertyKey('testkey'));0;`
         );
     });
 

--- a/src/builders/VertexCentricIndexBuilder.ts
+++ b/src/builders/VertexCentricIndexBuilder.ts
@@ -50,7 +50,7 @@ export class VertexCentricIndexBuilder implements Builder<string> {
                 `Unable to generate vc index ${this._name} with no edge label.`
             );
         }
-        let output = `if (!mgmt.containsGraphIndex('${this._name}')) `;
+        let output = `if (!mgmt.containsRelationIndex(mgmt.getEdgeLabel('${this._edgelabel}'), '${this._name}')) `;
         output += `mgmt.buildEdgeIndex(`;
         output += `mgmt.getEdgeLabel('${this._edgelabel}'), `;
         output += `'${this._name}', `;
@@ -59,6 +59,6 @@ export class VertexCentricIndexBuilder implements Builder<string> {
         output += [...this._keys]
             .map((key) => `mgmt.getPropertyKey('${key}')`)
             .join(', ');
-        return output.concat(');');
+        return output.concat(');0;');
     }
 }


### PR DESCRIPTION
Most of these changes are upgrades to JanusGraph 0.5.3 from older, unsupported method signatures.

There are also a few bug fixes for REINDEX'ing the VC indices and not returning a non-serializable database object during creation.