### PR TITLE
Enable index builds for Edge elements

### DIFF
--- a/src/JanusGraphManager.ts
+++ b/src/JanusGraphManager.ts
@@ -94,7 +94,10 @@ export class JanusGraphManager {
      */
     async createGraphIndex(index: GraphIndex, commit = false): Promise<number> {
         await this.init();
-        const builder = new GraphIndexBuilder(index.name);
+        const builder = new GraphIndexBuilder(
+            index.name,
+            index.element ?? 'Vertex'
+        );
         builder
             .label(index.label)
             .type(index.type)
@@ -226,7 +229,11 @@ export class JanusGraphManager {
             });
             const vci = schema.vcIndices.map((i) => {
                 const builder = new EnableIndexBuilder(i.name, schema.name);
-                return builder.type('VertexCentric').label(i.edgelabel).action('REINDEX').build();
+                return builder
+                    .type('VertexCentric')
+                    .label(i.edgelabel)
+                    .action('REINDEX')
+                    .build();
             });
             const count = (
                 await Promise.all(

--- a/src/builders/GraphIndexBuilder.spec.ts
+++ b/src/builders/GraphIndexBuilder.spec.ts
@@ -3,7 +3,7 @@ import { GraphIndexBuilder } from './GraphIndexBuilder';
 
 describe('GraphIndexBuilder', () => {
     it('should be instantiated with a name and key', () => {
-        const gib = new GraphIndexBuilder('test');
+        const gib = new GraphIndexBuilder('test', 'Vertex');
         const key = {
             field: 'testfield',
             mapping: 'STRING',
@@ -16,8 +16,22 @@ describe('GraphIndexBuilder', () => {
         );
     });
 
+    it('should be instantiated with a name, key, and element class', () => {
+        const gib = new GraphIndexBuilder('test', 'Edge');
+        const key = {
+            field: 'testfield',
+            mapping: 'STRING',
+        } as IndexKey;
+        const out = gib.key(key).build();
+        // Conditional build
+        expect(out).toContain(`if (!mgmt.containsGraphIndex('test'))`);
+        expect(out).toContain(
+            `mgmt.buildIndex('test', Edge.class).addKey(mgmt.getPropertyKey('testfield')).buildCompositeIndex();`
+        );
+    });
+
     it('should be instantiated with a name and multiple keys', () => {
-        const gib = new GraphIndexBuilder('test');
+        const gib = new GraphIndexBuilder('test', 'Vertex');
         const [key1, key2] = [
             {
                 field: 'testfield1',
@@ -34,7 +48,7 @@ describe('GraphIndexBuilder', () => {
     });
 
     it('should set unique', () => {
-        const gib = new GraphIndexBuilder('test');
+        const gib = new GraphIndexBuilder('test', 'Vertex');
         const key = {
             field: 'testfield',
             mapping: 'STRING',
@@ -44,7 +58,7 @@ describe('GraphIndexBuilder', () => {
     });
 
     it('should set a label', () => {
-        const gib = new GraphIndexBuilder('test');
+        const gib = new GraphIndexBuilder('test', 'Vertex');
         const key = {
             field: 'testfield',
             mapping: 'STRING',
@@ -54,7 +68,7 @@ describe('GraphIndexBuilder', () => {
     });
 
     it('should build a mixed index', () => {
-        const gib = new GraphIndexBuilder('test');
+        const gib = new GraphIndexBuilder('test', 'Vertex');
         const key = {
             field: 'testfield',
             mapping: 'STRING',
@@ -67,7 +81,7 @@ describe('GraphIndexBuilder', () => {
     });
 
     it('should build a mixed index with no mapping key', () => {
-        const gib = new GraphIndexBuilder('test');
+        const gib = new GraphIndexBuilder('test', 'Vertex');
         const key = {
             field: 'testfield',
         } as IndexKey;
@@ -77,7 +91,7 @@ describe('GraphIndexBuilder', () => {
     });
 
     it('should build a mixed index with custom backend', () => {
-        const gib = new GraphIndexBuilder('test');
+        const gib = new GraphIndexBuilder('test', 'Vertex');
         const key = {
             field: 'testfield',
             mapping: 'STRING',
@@ -90,7 +104,7 @@ describe('GraphIndexBuilder', () => {
     });
 
     it('should ignore duplicate keys', () => {
-        const gib = new GraphIndexBuilder('test');
+        const gib = new GraphIndexBuilder('test', 'Vertex');
         const key = {
             field: 'testfield',
             mapping: 'STRING',

--- a/src/builders/GraphIndexBuilder.ts
+++ b/src/builders/GraphIndexBuilder.ts
@@ -1,5 +1,9 @@
 import { Builder } from './Builder.interface';
-import { CompositeOrMixedIndexType, IndexKey } from '../types/GraphIndex';
+import {
+    CompositeOrMixedIndexType,
+    ElementClass,
+    IndexKey,
+} from '../types/GraphIndex';
 
 /**
  * Index Builder for Composite or Mixed indices.
@@ -13,7 +17,7 @@ export class GraphIndexBuilder implements Builder<string> {
     private _label?: string;
     private _backend?: string;
 
-    constructor(private _name: string) {}
+    constructor(private _name: string, private _element: ElementClass) {}
 
     type(type: CompositeOrMixedIndexType): this {
         this._type = type;
@@ -53,7 +57,7 @@ export class GraphIndexBuilder implements Builder<string> {
             );
         }
         let output = `if (!mgmt.containsGraphIndex('${this._name}')) `;
-        output += `mgmt.buildIndex('${this._name}', Vertex.class)`;
+        output += `mgmt.buildIndex('${this._name}', ${this._element}.class)`;
         output += [...this._keys]
             .map(
                 (key) =>

--- a/src/types/GraphIndex.ts
+++ b/src/types/GraphIndex.ts
@@ -1,5 +1,6 @@
 export type GraphIndex = {
     name: string;
+    element: ElementClass;
     keys: IndexKey[];
     type: CompositeOrMixedIndexType;
     unique?: boolean;
@@ -18,3 +19,5 @@ export type CompositeOrMixedIndexType = 'Composite' | 'Mixed';
 export type VertexCentricIndexType = 'VertexCentric';
 
 export type IndexType = CompositeOrMixedIndexType | VertexCentricIndexType;
+
+export type ElementClass = 'Vertex' | 'Edge';


### PR DESCRIPTION
Fixes #5 -- Adds an ElementClass type and allows the indexbuilder to set that as either vertex or edge.

This allows Composite/Mixed index generation of Edge elements.