### PR TITLE
feat: separated reindex function and enable_index function.

### DIFF
--- a/src/builders/WaitForIndexBuilder.ts
+++ b/src/builders/WaitForIndexBuilder.ts
@@ -9,9 +9,9 @@ export class WaitForIndexBuilder implements Builder<string> {
      * @param name Name of the index to wait for.
      * @param graph Name of the graph to use. Default is `graph`
      */
-    constructor(private name: string, private graph = 'graph') {}
+    constructor(private name: string, private graph: string = 'graph') {}
 
     build(): string {
-        return `ManagementSystem.awaitGraphIndexStatus(${this.graph}, '${this.name}').call()`;
+        return `ManagementSystem.awaitGraphIndexStatus(${this.graph}, '${this.name}').status(SchemaStatus.ENABLED, SchemaStatus.REGISTERED).call().toString()`;
     }
 }


### PR DESCRIPTION
Previously, calling enableIndices actually forced a reindex. This is obviously not something you want to do if your graph already has a ton of data in it.

This PR separates the two into two separate functions.

Also provided is a way (with the `reindex` function) to call an arbitrary reindex on an arbitrary graph and single index.