### PR TITLE
fix: fixed label-only edge index creation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@asymmetrik/janusgraph-manager",
-    "version": "0.5.4",
+    "version": "0.5.5",
     "description": "Janusgraph management tooling in NodeJS/Typescript",
     "keywords": [
         "janusgraph",

--- a/src/builders/GraphIndexBuilder.spec.ts
+++ b/src/builders/GraphIndexBuilder.spec.ts
@@ -57,7 +57,7 @@ describe('GraphIndexBuilder', () => {
         expect(out).toContain(`.unique()`);
     });
 
-    it('should set a label', () => {
+    it('should set a label for a vertex index', () => {
         const gib = new GraphIndexBuilder('test', 'Vertex');
         const key = {
             field: 'testfield',
@@ -65,6 +65,16 @@ describe('GraphIndexBuilder', () => {
         } as IndexKey;
         const out = gib.key(key).label('testlabel').build();
         expect(out).toContain(`.indexOnly(mgmt.getVertexLabel('testlabel'))`);
+    });
+
+    it('should set a label for an edge index', () => {
+        const gib = new GraphIndexBuilder('test', 'Edge');
+        const key = {
+            field: 'testfield',
+            mapping: 'STRING',
+        } as IndexKey;
+        const out = gib.key(key).label('testlabel').build();
+        expect(out).toContain(`.indexOnly(mgmt.getEdgeLabel('testlabel'))`);
     });
 
     it('should build a mixed index', () => {

--- a/src/builders/GraphIndexBuilder.ts
+++ b/src/builders/GraphIndexBuilder.ts
@@ -71,7 +71,7 @@ export class GraphIndexBuilder implements Builder<string> {
         output += this._unique ? `.unique()` : '';
         output +=
             this._label != null
-                ? `.indexOnly(mgmt.getVertexLabel('${this._label}'))`
+                ? `.indexOnly(mgmt.get${this._element}Label('${this._label}'))`
                 : '';
         return output.concat(
             this._type === 'Mixed'

--- a/src/builders/WaitForIndexBuilder.spec.ts
+++ b/src/builders/WaitForIndexBuilder.spec.ts
@@ -4,14 +4,14 @@ describe('WaitForIndexBuilder', () => {
     it('should build a wait string based on name and default graph', () => {
         const wfib = new WaitForIndexBuilder('testindex');
         expect(wfib.build()).toEqual(
-            `ManagementSystem.awaitGraphIndexStatus(graph, 'testindex').call()`
+            `ManagementSystem.awaitGraphIndexStatus(graph, 'testindex').status(SchemaStatus.ENABLED, SchemaStatus.REGISTERED).call().toString()`
         );
     });
 
-    it('should build a wait string based on name and custome graph', () => {
+    it('should build a wait string based on name and custom graph', () => {
         const wfib = new WaitForIndexBuilder('testindex', 'testgraph');
         expect(wfib.build()).toEqual(
-            `ManagementSystem.awaitGraphIndexStatus(testgraph, 'testindex').call()`
+            `ManagementSystem.awaitGraphIndexStatus(testgraph, 'testindex').status(SchemaStatus.ENABLED, SchemaStatus.REGISTERED).call().toString()`
         );
     });
 });


### PR DESCRIPTION
While a previous fix had allowed us to create edge indicies correctly, apparently it didn't work if you created a label-specific edge index, due to me not updating a hardcoded getGraphLabel string later in the build command.

This fixes the issue, as well as corrects a test case that was failing.